### PR TITLE
Enable sorting for custom field columns

### DIFF
--- a/app/bundles/LeadBundle/Controller/FieldController.php
+++ b/app/bundles/LeadBundle/Controller/FieldController.php
@@ -39,20 +39,18 @@ class FieldController extends FormController
 
         $limit  = $session->get('mautic.leadfield.limit', $this->coreParametersHelper->get('default_pagelimit'));
         $search = $request->get('search', $session->get('mautic.leadfield.filter', ''));
-        $session->set('mautic.leadfilter.filter', $search);
+        $session->set('mautic.leadfield.filter', $search);
 
         // do some default filtering
-        $orderBy    = $request->getSession()->get('mautic.leadfilter.orderby', 'f.order');
-        $orderByDir = $request->getSession()->get('mautic.leadfilter.orderbydir', 'ASC');
+        $orderBy    = $request->getSession()->get('mautic.leadfield.orderby', 'f.order');
+        $orderByDir = $request->getSession()->get('mautic.leadfield.orderbydir', 'ASC');
 
         $start = (1 === $page) ? 0 : (($page - 1) * $limit);
         if ($start < 0) {
             $start = 0;
         }
 
-        $search  = $request->get('search', $session->get('mautic.lead.emailtoken.filter', ''));
-
-        $session->set('mautic.lead.emailtoken.filter', $search);
+        // $search is already retrieved above and stored in the session
 
         $fields = $fieldModel->getEntities([
             'start'      => $start,

--- a/app/bundles/LeadBundle/Resources/views/Field/list.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Field/list.html.twig
@@ -56,12 +56,42 @@
                     'checkall': 'true',
                     'target': '#leadFieldTable',
                 }) }}
-                  <th class="col-leadfield-label">{{ 'mautic.lead.field.label'|trans }}</th>
-                  <th class="visible-md visible-lg col-leadfield-alias">{{ 'mautic.core.alias'|trans }}</th>
-                  <th class="visible-md visible-lg col-leadfield-group">{{ 'mautic.lead.field.object'|trans }}</th>
-                  <th class="visible-md visible-lg col-leadfield-group">{{ 'mautic.lead.field.group'|trans }}</th>
-                  <th class="col-leadfield-type">{{ 'mautic.lead.field.type'|trans }}</th>
-                  <th class="visible-md visible-lg col-leadfield-id">{{ 'mautic.core.id'|trans }}</th>
+                  {{ include('@MauticCore/Helper/tableheader.html.twig', {
+                    'sessionVar': 'leadfield',
+                    'text': 'mautic.lead.field.label',
+                    'class': 'col-leadfield-label',
+                    'orderBy': 'f.label',
+                  }) }}
+                  {{ include('@MauticCore/Helper/tableheader.html.twig', {
+                    'sessionVar': 'leadfield',
+                    'text': 'mautic.core.alias',
+                    'class': 'visible-md visible-lg col-leadfield-alias',
+                    'orderBy': 'f.alias',
+                  }) }}
+                  {{ include('@MauticCore/Helper/tableheader.html.twig', {
+                    'sessionVar': 'leadfield',
+                    'text': 'mautic.lead.field.object',
+                    'class': 'visible-md visible-lg col-leadfield-group',
+                    'orderBy': 'f.object',
+                  }) }}
+                  {{ include('@MauticCore/Helper/tableheader.html.twig', {
+                    'sessionVar': 'leadfield',
+                    'text': 'mautic.lead.field.group',
+                    'class': 'visible-md visible-lg col-leadfield-group',
+                    'orderBy': 'f.group',
+                  }) }}
+                  {{ include('@MauticCore/Helper/tableheader.html.twig', {
+                    'sessionVar': 'leadfield',
+                    'text': 'mautic.lead.field.type',
+                    'class': 'col-leadfield-type',
+                    'orderBy': 'f.type',
+                  }) }}
+                  {{ include('@MauticCore/Helper/tableheader.html.twig', {
+                    'sessionVar': 'leadfield',
+                    'text': 'mautic.core.id',
+                    'class': 'visible-md visible-lg col-leadfield-id',
+                    'orderBy': 'f.id',
+                  }) }}
                   <th class="visible-sm visible-md visible-lg col-leadfield-statusicons"></th>
               </tr>
               </thead>


### PR DESCRIPTION
## Summary
- Fix session variables to store custom field list ordering and filtering
- Add sortable table headers to the custom field list

## Testing
- `composer test` *(fails: Tests: 4700, Errors: 1557)*

------
https://chatgpt.com/codex/tasks/task_e_689a17156c4c8325b3575ae8cdee2484