### PR TITLE
Code review suggestion: Use field helper settings to select filter

### DIFF
--- a/app/bundles/FormBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/CampaignSubscriber.php
@@ -104,11 +104,7 @@ class CampaignSubscriber implements EventSubscriberInterface
         $field = $this->formModel->findFormFieldByAlias($form, $event->getConfig()['field']);
 
         $filter = $this->formFieldHelper->getFieldFilter($field->getType());
-        if (in_array($field->getType(), ['select', 'radiogrp', 'checkboxgrp'])) {
-            $value = InputHelper::_($event->getConfig()['value'], 'raw');
-        } else {
-            $value = InputHelper::_($event->getConfig()['value'], $filter);
-        }
+        $value  = InputHelper::_($event->getConfig()['value'], $filter);
 
         $result = $this->formSubmissionModel->getRepository()->compareValue(
             $lead->getId(),

--- a/app/bundles/FormBundle/Helper/FormFieldHelper.php
+++ b/app/bundles/FormBundle/Helper/FormFieldHelper.php
@@ -30,7 +30,9 @@ class FormFieldHelper extends AbstractFormFieldHelper
                 Blank::class => ['message' => 'mautic.form.submission.captcha.invalid'],
             ],
         ],
-        'checkboxgrp' => [],
+        'checkboxgrp' => [
+            'filter' => 'raw',
+        ],
         'country'     => [],
         'date'        => [],
         'datetime'    => [],
@@ -49,8 +51,12 @@ class FormFieldHelper extends AbstractFormFieldHelper
         ],
         'pagebreak' => [],
         'password'  => [],
-        'radiogrp'  => [],
-        'select'    => [],
+        'radiogrp'  => [
+            'filter' => 'raw',
+        ],
+        'select'    => [
+            'filter' => 'raw',
+        ],
         'tel'       => [],
         'text'      => [],
         'textarea'  => [],


### PR DESCRIPTION
Suggestion: Use field helper settings to select filter

- Keeping consistent with previous practice.
- Avoids another if switch path to cover with tests (Sonarqube did call this out on the original pull request)

If this seems riskier: I did check the usage of these functions and this `types` property and usage was limited to only a couple of places in the code.